### PR TITLE
Fix manifests cleanup

### DIFF
--- a/Libvirt.md
+++ b/Libvirt.md
@@ -286,3 +286,6 @@ tf_libvirt_cloud_inits:
 but you can check the [cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/reference/examples.html)
 to see how it is possible to change `cfg` contents and so the clod-init
 behavior.
+
+Note that for each run of `tfs_generator.yml` playbook a cleanup is made to
+ensure that there are no residual `.tf` and `.cfg` files from previous runs.

--- a/tasks/azure-cleanup.yml
+++ b/tasks/azure-cleanup.yml
@@ -1,0 +1,54 @@
+---
+
+- name: Generate list of .tf files to keep
+  ansible.builtin.set_fact:
+    files_to_keep: []
+
+- name: Add fixed resources files to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/azure/' + item + '.tf' ] }}"
+  with_items:
+    - "{{ azure_resources }}"
+    - "{{ azure_vpn_resources }}"
+
+- name: Add key_vault.tf resource file to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/azure/key_vault.tf' }}"
+  when:
+    - azure_key_vault_enable | bool
+
+- name: Add database.tf resource file to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/azure/database.tf' }}"
+  when:
+    - azure_database_servers is defined
+
+- name: Add dynamic .vms.tf files to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.vms.tf' ] }}"
+  with_items:
+    - "{{ azure_vms_groups }}"
+
+- name: Get the stats (including absolute paths) of the remote files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ files_to_keep }}"
+  register: files_to_keep_stats
+
+- name: Create a list of files to keep with absolute paths
+  ansible.builtin.set_fact:
+    files_to_keep_full_path: "{{ files_to_keep_full_path | default([]) + [ item.stat.path ] }}"
+  loop: "{{ files_to_keep_stats.results }}"
+
+- name: Generate the list of all the .tf files
+  ansible.builtin.find:
+    paths: "{{ tf_config_dir }}"
+    patterns: "*.tf,*.cfg"
+  register: all_files
+
+- name: Effectively delete files not to keep
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ all_files.files }}"
+  when: item.path not in files_to_keep_full_path

--- a/tasks/azure.yml
+++ b/tasks/azure.yml
@@ -109,6 +109,9 @@
   loop_control:
     loop_var: group_name
 
+- name: Cleanup Azure manifests
+  ansible.builtin.include_tasks: azure-cleanup.yml
+
 - name: Display a reminder for sourcing variables
   ansible.builtin.debug:
     msg:

--- a/tasks/libvirt-cleanup.yml
+++ b/tasks/libvirt-cleanup.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Generate list of .tf and .cfg files to keep
+  ansible.builtin.set_fact:
+    files_to_keep: []
+
+- name: Add fixed resources files to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.tf' ] }}"
+  with_items:
+    - 'provider'
+    - 'networks'
+    - 'pools'
+    - 'volumes'
+    - 'cloud_init'
+
+- name: Add dynamic cloud_init.cfg files to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/cloud_init_' + item.name + '.cfg' ] }}"
+  with_items:
+    - "{{ tf_libvirt_cloud_inits }}"
+
+- name: Add dynamic .vms.tf files to keep list
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.vms.tf' ] }}"
+  with_items:
+    - "{{ tf_libvirt_vms_groups }}"
+
+- name: Get the stats (including absolute paths) of the remote files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ files_to_keep }}"
+  register: files_to_keep_stats
+
+- name: Create a list of files to keep with absolute paths
+  ansible.builtin.set_fact:
+    files_to_keep_full_path: "{{ files_to_keep_full_path | default([]) + [ item.stat.path ] }}"
+  loop: "{{ files_to_keep_stats.results }}"
+
+- name: Generate the list of all the .tf and .cfg files
+  ansible.builtin.find:
+    paths: "{{ tf_config_dir }}"
+    patterns: "*.tf,*.cfg"
+  register: all_files
+
+- name: Effectively delete files not to keep
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ all_files.files }}"
+  when: item.path not in files_to_keep_full_path

--- a/tasks/libvirt.yml
+++ b/tasks/libvirt.yml
@@ -56,6 +56,58 @@
   loop_control:
     loop_var: tf_group_name
 
+# Generate the files_to_keep list
+- name: Create the list of .tf and .cfg files to keep
+  ansible.builtin.set_fact:
+    files_to_keep: []
+
+- name: Add to files to keep list fixed resources files
+  ansible.builtin.set_fact:
+     files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.tf' ] }}"
+  with_items:
+    - 'provider'
+    - 'networks'
+    - 'pools'
+    - 'volumes'
+    - 'cloud_init'
+
+- name: Add to files to keep list dynamic cloud_init.cfg files
+  ansible.builtin.set_fact:
+     files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/cloud_init_' + item.name + '.cfg' ] }}"
+  with_items:
+    - "{{ tf_libvirt_cloud_inits }}"
+
+- name: Add to files to keep list dynamic .vms.tf files
+  ansible.builtin.set_fact:
+    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.vms.tf' ] }}"
+  with_items:
+    - "{{ tf_libvirt_vms_groups }}"
+
+- name: Get the stats (including absolute paths) of the remote files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ files_to_keep }}"
+  register: files_to_keep_stats
+
+- name: Create a list of files to keep with absolute paths
+  set_fact:
+    files_to_keep_full_path: "{{ files_to_keep_full_path | default([]) + [ item.stat.path ] }}"
+  loop: "{{ files_to_keep_stats.results }}"
+
+# Generate the list of all files
+- name: Find all .tf and .cfg files in tf_config_dir
+  find:
+    paths: "{{ tf_config_dir }}"
+    patterns: "*.tf,*.cfg"
+  register: all_files
+
+- name: Delete files not to keep
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ all_files.files }}"
+  when: item.path not in files_to_keep_full_path
+
 - name: Display a reminder for sourcing variables
   ansible.builtin.debug:
     msg:

--- a/tasks/libvirt.yml
+++ b/tasks/libvirt.yml
@@ -56,57 +56,8 @@
   loop_control:
     loop_var: tf_group_name
 
-# Generate the files_to_keep list
-- name: Create the list of .tf and .cfg files to keep
-  ansible.builtin.set_fact:
-    files_to_keep: []
-
-- name: Add to files to keep list fixed resources files
-  ansible.builtin.set_fact:
-     files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.tf' ] }}"
-  with_items:
-    - 'provider'
-    - 'networks'
-    - 'pools'
-    - 'volumes'
-    - 'cloud_init'
-
-- name: Add to files to keep list dynamic cloud_init.cfg files
-  ansible.builtin.set_fact:
-     files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/cloud_init_' + item.name + '.cfg' ] }}"
-  with_items:
-    - "{{ tf_libvirt_cloud_inits }}"
-
-- name: Add to files to keep list dynamic .vms.tf files
-  ansible.builtin.set_fact:
-    files_to_keep: "{{ files_to_keep + [ tf_config_dir + '/' + item + '.vms.tf' ] }}"
-  with_items:
-    - "{{ tf_libvirt_vms_groups }}"
-
-- name: Get the stats (including absolute paths) of the remote files
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop: "{{ files_to_keep }}"
-  register: files_to_keep_stats
-
-- name: Create a list of files to keep with absolute paths
-  set_fact:
-    files_to_keep_full_path: "{{ files_to_keep_full_path | default([]) + [ item.stat.path ] }}"
-  loop: "{{ files_to_keep_stats.results }}"
-
-# Generate the list of all files
-- name: Find all .tf and .cfg files in tf_config_dir
-  find:
-    paths: "{{ tf_config_dir }}"
-    patterns: "*.tf,*.cfg"
-  register: all_files
-
-- name: Delete files not to keep
-  file:
-    path: "{{ item.path }}"
-    state: absent
-  loop: "{{ all_files.files }}"
-  when: item.path not in files_to_keep_full_path
+- name: Cleanup Libvirt manifests and configurations
+  ansible.builtin.include_tasks: libvirt-cleanup.yml
 
 - name: Display a reminder for sourcing variables
   ansible.builtin.debug:


### PR DESCRIPTION
This work should prevent confusion with frequently updated repositories, by cleaning up unused files.